### PR TITLE
CI: Test all supported Python versions - load versions dynamically

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master' && github.repository == 'commaai/body-jim'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-tags: true
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.11'
     - name: Bump version and tag

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,12 +3,27 @@ name: tests
 on: [push, pull_request]
 
 jobs:
+  fetch-versions:
+    runs-on: ubuntu-20.04
+    steps:
+        - id: filter-versions
+          run: |
+            API_RESPONSE=$(curl -s https://endoflife.date/api/python.json)
+
+            # Filter versions based on EOL date and format output as JSON array
+            FILTERED_VERSIONS=$(echo $API_RESPONSE | jq -c '[.[] | select(.eol > "'$(date +"%Y-%m-%d")'") | .cycle]')
+
+            echo "versions=$FILTERED_VERSIONS" >> $GITHUB_OUTPUT
+    outputs:
+      versions: ${{ steps.filter-versions.outputs.versions }}
+
   test:
     runs-on: ubuntu-20.04
+    needs: fetch-versions
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ${{ fromJson(needs.fetch-versions.outputs.versions) }}
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,11 +5,14 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install package
       run: pip install -e .[dev]
     - name: Unit Tests
@@ -17,11 +20,14 @@ jobs:
         cd tests/; python -m unittest discover
   static_analysis:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Static analysis

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,6 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -20,14 +20,11 @@ jobs:
         cd tests/; python -m unittest discover
   static_analysis:
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.11'
     - name: Install pre-commit
       run: pip install pre-commit
     - name: Static analysis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name="Vehicle Researcher", email="user@comma.ai" }]
 description = "Comma body gymnasium API"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.11"
+requires-python = ">=3.8"
 classifiers = [
   "Programming Language :: Python :: 3",
   "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
I added a job to the test workflow which fills in the matrix based on all currently supported python versions from [here](https://endoflife.date/api/python.json)

Closes #9 #10 
Based on #10 